### PR TITLE
Fixing gradle dependency, as well as version in maven dependency on doc page

### DIFF
--- a/_includes/gradle-coords.txt
+++ b/_includes/gradle-coords.txt
@@ -1,0 +1,4 @@
+implementation ("org.tribuo:tribuo-all:{{ site.tribuo_version }}@pom") {
+    transitive = true // for Groovy
+    // isTransitive = true // for Kotlin
+}

--- a/community.html
+++ b/community.html
@@ -31,7 +31,7 @@ description: Get involved in the Tribuo community. Join our development list, re
                     <p>We're investigating a few options for real-time chat. Check back in the near future.</p>
                     <h4>Issues</h4>
                     <p>For bug reports, feature requests, or other issues, please file an issue on <a href="https://github.com/oracle/tribuo/issues">Github</a>.</p>
-                    <p>Security issues should be submitted according to our <a href="https://github.com/oracle/tribuo/blob/writing-docs/SECURITY.md">reporting guidelines.</a></p>
+                    <p>Security issues should be submitted according to our <a href="https://github.com/oracle/tribuo/blob/writing-docs/SECURITY.md">reporting guidelines</a>.</p>
                     <h4>Contributing</h4>
                     <p>We welcome contributions! See our <a href="https://github.com/oracle/tribuo/blob/writing-docs/CONTRIBUTING.md">contribution guidelines</a>.</p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@ active: home
         </div>
         <div class="tab-pane fade justify-content-center" id="gradle" role="tabpanel" aria-labelledby="profile-tab">
             <div class="d-flex alert alert-danger align-items-center bg-red-tribuo overflow-source-links" role="alert">
-                <code id="gradle-coords" class="copy-url preformat">implementation 'org.tribuo:tribuo-all:{{ site.tribuo_version }}@pom'</code>
+                <code id="gradle-coords" class="copy-url preformat">{% include gradle-coords.txt %}</code>
                 <button class="btn btn-sm float-right" data-clipboard-action="copy" data-clipboard-target="#gradle-coords">
                     <img src="assets/img/copy_to_clipboard.svg" alt="Copy to clipboard" width="18" />
                 </button>

--- a/learn/4.0/docs/index.html
+++ b/learn/4.0/docs/index.html
@@ -85,7 +85,7 @@ var eval     = new LabelEvaluator().evaluate(new LibSVMDataSource(Paths.get("tes
 <dependency>
     <groupId>org.tribuo</groupId>
     <artifactId>tribuo-all</artifactId>
-    <version>4.0.1</version>
+    <version>{% endraw %}{{ site.tribuo_version }}{% raw %}</version>
     <type>pom</type>
 </dependency>
 {% endraw %}

--- a/learn/4.0/tutorials/index.html
+++ b/learn/4.0/tutorials/index.html
@@ -59,8 +59,8 @@ nav_order: 103
         <h3>Gradle</h3>
         <p>
 {% highlight groovy %}
-implementation 'org.tribuo:tribuo-all:{{ site.tribuo_version }}@pom'
-{% endhighlight xml %}
+{% include gradle-coords.txt %}
+{% endhighlight %}
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
Gradle dependency text is now a separate file we can just include anywhere. Also fixed maven dependency on docs page to have an auto-generated version. Made a minor formatting change on community page while I was at it.