### PR TITLE
Fixing the javadoc links in the regression tutorial

### DIFF
--- a/learn/4.0/tutorials/regression-tribuo-v4.html
+++ b/learn/4.0/tutorials/regression-tribuo-v4.html
@@ -382,7 +382,7 @@ Evaluation (test):
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Using a more robust optimizer got us a better fit in the same number of epochs. However, both the train and test R^2 scores are still substantially less than 1 and, as before, the train and test RMSE scores are very similar.</p>
-<p>See <a href="http://akyrillidis.github.io/notes/AdaGrad">here</a> and <a href="http://ruder.io/optimizing-gradient-descent/index.html#adagrad">here</a> for more on AdaGrad. Also, there are many other implementations of various well-known optimizers in Tribuo, including <a href="https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/Adam.html">Adam</a> and <a href="https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/RMSProp.html">RMSProp</a>. See the <a href="https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/package-summary.html">math.optimisers</a> package.</p>
+<p>See <a href="http://akyrillidis.github.io/notes/AdaGrad">here</a> and <a href="http://ruder.io/optimizing-gradient-descent/index.html#adagrad">here</a> for more on AdaGrad. Also, there are many other implementations of various well-known optimizers in Tribuo, including <a href="https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/Adam.html">Adam</a> and <a href="https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/RMSProp.html">RMSProp</a>. See the <a href="https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/package-summary.html">math.optimisers</a> package.</p>
 
 </div>
 </div>


### PR DESCRIPTION
I missed this update when I fixed the links in the Tribuo repo.