### PR TITLE
Introduced sitemap.xml to specify relative priority of documentation versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,14 +11,10 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.9.0"
 gem "bigdecimal"
 
-# Theme: "Just the Docs" https://pmarsceill.github.io/just-the-docs/
-gem "just-the-docs"
-
 gem "kramdown-parser-gfm", "~> 1.1.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.15.1"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bigdecimal (3.0.2)
     colorator (1.1.0)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.15.1)
+    ffi (1.15.3)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -28,18 +28,10 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.15.1)
-      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.7.1)
-      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.3.3)
-      jekyll (>= 3.8.5)
-      jekyll-seo-tag (~> 2.0)
-      rake (>= 12.3.1, < 13.1.0)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -52,7 +44,6 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    rake (13.0.3)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -71,8 +62,6 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal
   jekyll (~> 3.9.0)
-  jekyll-feed (~> 0.15.1)
-  just-the-docs
   kramdown-parser-gfm (~> 1.1.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,8 @@ defaults:
       layout: learn-outdated
       version: 4.0
       active: learn
+      sitemap:
+        priority: 0.25
   -
     scope:
       path: "learn/*/tutorials/*"
@@ -73,9 +75,9 @@ defaults:
 # Build settings
 markdown: kramdown
 plugins:
-- jekyll-feed
+#- jekyll-feed
 
-# Theme settings
+# My settings
 search_enabled: true
 
 # Exclude from processing.

--- a/news.html
+++ b/news.html
@@ -5,6 +5,8 @@ author: all
 nav_order: 2
 permalink: /news/
 active: news
+sitemap:
+  exclude: 'yes' # this stub is just a placeholder
 ---
 <ul>
     {% for post in site.posts %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,53 @@
+---
+layout: null
+sitemap:
+    exclude: 'yes'
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- sitemap generated at {{ site.time | date_to_xmlschema }} -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for post in site.posts %}
+    {% unless post.published == false %}
+    <url>
+        <loc>{{ site.url }}{{ post.url }}</loc>
+        {% if post.sitemap.lastmod %}
+        <lastmod>{{ post.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+        {% elsif post.date %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+        {% endif %}
+        {% if post.sitemap.changefreq %}
+        <changefreq>{{ post.sitemap.changefreq }}</changefreq>
+        {% else %}
+        <changefreq>weekly</changefreq>
+        {% endif %}
+        {% if post.sitemap.priority %}
+        <priority>{{ post.sitemap.priority }}</priority>
+        {% else %}
+        <priority>0.5</priority>
+        {%- endif -%}
+    </url>
+    {% endunless %}
+{% endfor %}
+{% for page in site.pages %}
+    {% unless page.sitemap.exclude == "yes" or page.url contains "assets" or page.url contains "search_data.js" %}
+    <url>
+        <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
+        {% if page.sitemap.lastmod %}
+        <lastmod>{{ page.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+        {% elsif page.date %}
+        <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
+        {% endif %}
+        {% if page.sitemap.changefreq %}
+        <changefreq>{{ page.sitemap.changefreq }}</changefreq>
+        {% else %}
+        <changefreq>weekly</changefreq>
+        {% endif %}
+        {% if page.sitemap.priority %}
+        <priority>{{ page.sitemap.priority }}</priority>
+        {% else %}
+        <priority>0.5</priority>
+        {% endif %}
+    </url>
+    {% endunless %}
+{% endfor %}
+</urlset>


### PR DESCRIPTION
This branch adds the automatic generation of a sitemap.xml file. The _config.xml includes settings that lowers the "priority" of older documentation versions. According to the sitemap schema, "you can use this tag to increase the likelihood that your most important pages are present in a search index". Most pages are assigned the default 0.5 relative priority, but the old documentation is given 0.25 priority. This branch also removes the feed plugin which wasn't being used (but would have been included in the sitemap) and updates a plugin due to security vulnerability.