### PR TITLE
Fixing the links in the community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -28,12 +28,12 @@ description: Get involved in the Tribuo community. Join our development list, re
                     <ul>
                         <li>Discussion list: <a href="mailto:tribuo-devel@oss.oracle.com">tribuo-devel@oss.oracle.com</a> (<a href="https://oss.oracle.com/pipermail/tribuo-devel/">archive</a>)</li>
                     </ul>
-                    <p>We're investigating a few options for real-time chat. Check back in the near future.</p>
+                    <p>We're investigating a few options for real-time chat.</p>
                     <h4>Issues</h4>
                     <p>For bug reports, feature requests, or other issues, please file an issue on <a href="https://github.com/oracle/tribuo/issues">GitHub</a>.</p>
-                    <p>Security issues should be submitted according to our <a href="https://github.com/oracle/tribuo/blob/writing-docs/SECURITY.md">reporting guidelines</a>.</p>
+                    <p>Security issues should be submitted according to our <a href="https://github.com/oracle/tribuo/blob/main/SECURITY.md">reporting guidelines</a>.</p>
                     <h4>Contributing</h4>
-                    <p>We welcome contributions! See our <a href="https://github.com/oracle/tribuo/blob/writing-docs/CONTRIBUTING.md">contribution guidelines</a>.</p>
+                    <p>We welcome contributions! See our <a href="https://github.com/oracle/tribuo/blob/main/CONTRIBUTING.md">contribution guidelines</a>.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The community page linked to the docs prep branch we made in the lead up to Tribuo's initial release. It should point at `main`.