### PR TITLE
Fixing OCA link on all the FAQ pages

### DIFF
--- a/learn/4.0/faq.md
+++ b/learn/4.0/faq.md
@@ -49,7 +49,7 @@ other feedback on our GitHub repo. The Tribuo mailing list is
 [here](https://oss.oracle.com/pipermail/tribuo-devel/). We're looking at
 different options for real time chat. Code contributions are accepted under the
 terms of the [Oracle Contributor
-Agreement](https://www.oracle.com/technetwork/community/oca-486395.html).
+Agreement](https://oca.opensource.oracle.com).
 Contributors must have sign the agreement before their PRs can be reviewed or
 merged.
 

--- a/learn/4.1/faq.md
+++ b/learn/4.1/faq.md
@@ -49,7 +49,7 @@ other feedback on our GitHub repo. The Tribuo mailing list is
 [here](https://oss.oracle.com/pipermail/tribuo-devel/). We're looking at
 different options for real time chat. Code contributions are accepted under the
 terms of the [Oracle Contributor
-Agreement](https://www.oracle.com/technetwork/community/oca-486395.html).
+Agreement](https://oca.opensource.oracle.com).
 Contributors must have sign the agreement before their PRs can be reviewed or
 merged.
 

--- a/learn/4.2/faq.md
+++ b/learn/4.2/faq.md
@@ -49,7 +49,7 @@ other feedback on our GitHub repo. The Tribuo mailing list is
 [here](https://oss.oracle.com/pipermail/tribuo-devel/). We're looking at
 different options for real time chat. Code contributions are accepted under the
 terms of the [Oracle Contributor
-Agreement](https://www.oracle.com/technetwork/community/oca-486395.html).
+Agreement](https://oca.opensource.oracle.com).
 Contributors must have sign the agreement before their PRs can be reviewed or
 merged.
 


### PR DESCRIPTION
Swapped to the new OCA link as we have the same bug as Tribuo's docs, fixed in https://github.com/oracle/tribuo/pull/249.